### PR TITLE
Instalação de plugin de internacionalização para o Jekyll como um submódulo do Git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_plugins/multiple-languages"]
+	path = _plugins/multiple-languages
+	url = git://github.com/screeninteraction/jekyll-multiple-languages-plugin.git


### PR DESCRIPTION
Instalação do Jekyll Multiple Languages como um submódulo do Git, permitindo o build do site com a tradução do conteúdo para inglês.